### PR TITLE
Gear/joh 28 pet and like endpoints

### DIFF
--- a/src/app/dto/pet.dto.go
+++ b/src/app/dto/pet.dto.go
@@ -28,6 +28,7 @@ type PetResponse struct {
 	Contact      string          `json:"contact"`
 	AdoptBy      string          `json:"adopt_by"`
 	Images       []ImageResponse `json:"images"`
+	IsLike       *bool           `json:"is_like"`
 }
 
 type CreatePetRequest struct {

--- a/src/app/handler/like/like.handler.go
+++ b/src/app/handler/like/like.handler.go
@@ -21,6 +21,18 @@ func NewHandler(service likeSvc.Service, validate validator.IDtoValidator) *Hand
 	return &Handler{service, validate}
 }
 
+// FindByUserId is a function that return all petID and userID that user liked.
+// @Summary find likes by user id
+// @Description Return dto.ResponseSuccess
+// @Param id path string true "user id"
+// @Tags like
+// @Accept json
+// @Produce json
+// @Success 200 {object} dto.ResponseSuccess
+// @Failure 404 {object} dto.ResponseNotfoundErr "user not found"
+// @Failure 500 {object} dto.ResponseInternalErr "Internal service error"
+// @Failure 503 {object} dto.ResponseServiceDownErr "Service is down"
+// @Router /v1/likes/ [get]
 func (h *Handler) FindByUserId(c router.IContext) {
 	id, err := c.Param("id")
 	if err != nil {
@@ -46,6 +58,18 @@ func (h *Handler) FindByUserId(c router.IContext) {
 	return
 }
 
+// Create is a function for creating a `like` for a pet that a user is interested
+// @Summary create like
+// @Description Return dto.ResponseSuccess
+// @Param create body dto.CreateLikeRequest true "create like request"
+// @Tags like
+// @Accept json
+// @Produce json
+// @Success 200 {object} dto.ResponseSuccess
+// @Failure 400 {object} dto.ResponseBadRequestErr "Invalid request body"
+// @Failure 500 {object} dto.ResponseInternalErr "Internal service error"
+// @Failure 503 {object} dto.ResponseServiceDownErr "Service is down"
+// @Router /v1/likes/ [post]
 func (h *Handler) Create(c router.IContext) {
 	request := &dto.CreateLikeRequest{}
 	err := c.Bind(request)
@@ -85,6 +109,18 @@ func (h *Handler) Create(c router.IContext) {
 	return
 }
 
+// Create is a function for delete like in database
+// @Summary delete like
+// @Description Return dto.ResponseSuccess if like is successfully deleted
+// @Param id path string true "user id"
+// @Tags like
+// @Accept json
+// @Produce json
+// @Success 200 {object} dto.ResponseSuccess
+// @Failure 404 {object} dto.ResponseNotfoundErr "like not found"
+// @Failure 500 {object} dto.ResponseInternalErr "Internal service error"
+// @Failure 503 {object} dto.ResponseServiceDownErr "Service is down"
+// @Router /v1/likes/ [delete]
 func (h *Handler) Delete(c router.IContext) {
 	id, err := c.Param("id")
 	if err != nil {

--- a/src/app/handler/pet/pet.handler.go
+++ b/src/app/handler/pet/pet.handler.go
@@ -26,14 +26,15 @@ func NewHandler(service petSvc.Service, imageService imageSvc.Service, validate 
 // FindAll is a function that return all pets in database
 // @Summary find all pets
 // @Description Return the data of pets if successfully
-// @Tags auth
+// @Tags pet
 // @Accept json
 // @Produce json
-// @Success 200 {object} dto.PetDto
+// @Success 200 {object} dto.ResponseSuccess
 // @Failure 500 {object} dto.ResponseInternalErr "Internal service error"
 // @Failure 503 {object} dto.ResponseServiceDownErr "Service is down"
 // @Router /v1/pets/ [get]
 func (h *Handler) FindAll(c router.IContext) {
+	token :=  
 	response, respErr := h.service.FindAll()
 	if respErr != nil {
 		c.JSON(respErr.StatusCode, respErr)
@@ -55,12 +56,13 @@ func (h *Handler) FindAll(c router.IContext) {
 // @Tags auth
 // @Accept json
 // @Produce json
-// @Success 200 {object} dto.PetDto
-// @Failure 400 {object} dto.ResponseBadRequestErr "Invalid request body"
+// @Success 200 {object} dto.ResponseSuccess
+// @Failure 404 {object} dto.ResponseNotfoundErr "Pet not found"
 // @Failure 500 {object} dto.ResponseInternalErr "Internal service error"
 // @Failure 503 {object} dto.ResponseServiceDownErr "Service is down"
 // @Router /v1/pets/{id} [get]
 func (h *Handler) FindOne(c router.IContext) {
+	token := c.Token()
 	id, err := c.Param("id")
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, dto.ResponseErr{
@@ -89,10 +91,10 @@ func (h *Handler) FindOne(c router.IContext) {
 // @Summary create pet
 // @Description Return the data of pet if successfully
 // @Param create body dto.CreatePetRequest true "pet dto"
-// @Tags auth
+// @Tags pet
 // @Accept json
 // @Produce json
-// @Success 201 {object} dto.PetDto
+// @Success 201 {object} dto.ResponseSuccess
 // @Failure 400 {object} dto.ResponseBadRequestErr "Invalid request body"
 // @Failure 500 {object} dto.ResponseInternalErr "Internal service error"
 // @Failure 503 {object} dto.ResponseServiceDownErr "Service is down"
@@ -140,12 +142,13 @@ func (h *Handler) Create(c router.IContext) {
 // @Summary update pet
 // @Description Return the data of pet if successfully
 // @Param update body dto.UpdatePetRequest true "update pet dto"
-// @Param id path stirng true "pet id"
-// @Tags auth
+// @Param id path string true "pet id"
+// @Tags pet
 // @Accept json
 // @Produce json
-// @Success 201 {object} dto.PetDto
+// @Success 201 {object} dto.ResponseSuccess
 // @Failure 400 {object} dto.ResponseBadRequestErr "Invalid request body"
+// @Failure 404 {object} dto.ResponseNotfoundErr "Pet not found"
 // @Failure 500 {object} dto.ResponseInternalErr "Internal service error"
 // @Failure 503 {object} dto.ResponseServiceDownErr "Service is down"
 // @Router /v1/pets/{id} [put]
@@ -202,13 +205,14 @@ func (h *Handler) Update(c router.IContext) {
 // Change is a function that change visibility of pet in database
 // @Summary change view pet
 // @Description Return the status true of pet if successfully else false
-// @Param change view body dto.ChangeViewPetRequest true "change view pet dto"
-// @Param id string true "pet id"
-// @Tags auth
+// @Param changeView body dto.ChangeViewPetRequest true "change view pet dto"
+// @Param id path string true "pet id"
+// @Tags pet
 // @Accept json
 // @Produce json
-// @Success 201 {object} bool
+// @Success 201 {object} dto.ResponseSuccess
 // @Failure 400 {object} dto.ResponseBadRequestErr "Invalid request body"
+// @Failure 404 {object} dto.ResponseNotfoundErr "Pet not found"
 // @Failure 500 {object} dto.ResponseInternalErr "Internal service error"
 // @Failure 503 {object} dto.ResponseServiceDownErr "Service is down"
 // @Router /v1/pets/ [put]
@@ -265,11 +269,11 @@ func (h *Handler) ChangeView(c router.IContext) {
 // Delete is a function that delete pet in database
 // @Summary delete pet
 // @Description Return the status true of pet if successfully else false
-// @Param id string true "pet id"
-// @Tags auth
+// @Param id path string true "pet id"
+// @Tags pet
 // @Accept json
 // @Produce json
-// @Success 201 {object} bool
+// @Success 201 {object} dto.ResponseSuccess
 // @Failure 400 {object} dto.ResponseBadRequestErr "Invalid request body"
 // @Failure 500 {object} dto.ResponseInternalErr "Internal service error"
 // @Failure 503 {object} dto.ResponseServiceDownErr "Service is down"
@@ -308,8 +312,9 @@ func (h *Handler) Delete(c router.IContext) {
 // @Tags pet
 // @Accept json
 // @Produce json
-// @Success 201 {object} bool
+// @Success 201 {object} dto.ResponseSuccess
 // @Failure 400 {object} dto.ResponseBadRequestErr "Invalid request body"
+// @Failure 404 {object} dto.ResponseNotfoundErr "Pet not found"
 // @Failure 500 {object} dto.ResponseInternalErr "Internal service error"
 // @Failure 503 {object} dto.ResponseServiceDownErr "Service is down"
 // @Router /v1/pets/{id}/adopt [put]

--- a/src/app/handler/pet/pet.handler_test.go
+++ b/src/app/handler/pet/pet.handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/isd-sgcu/johnjud-gateway/src/constant/pet"
 	routerMock "github.com/isd-sgcu/johnjud-gateway/src/mocks/router"
 	imageMock "github.com/isd-sgcu/johnjud-gateway/src/mocks/service/image"
+	likeMock "github.com/isd-sgcu/johnjud-gateway/src/mocks/service/like"
 	petMock "github.com/isd-sgcu/johnjud-gateway/src/mocks/service/pet"
 	validatorMock "github.com/isd-sgcu/johnjud-gateway/src/mocks/validator"
 
@@ -141,13 +142,14 @@ func (t *PetHandlerTest) TestFindAllSuccess() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
 	petSvc.EXPECT().FindAll().Return(findAllResponse, nil)
 	context.EXPECT().JSON(http.StatusOK, expectedResponse)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.FindAll(context)
 }
 
@@ -163,6 +165,7 @@ func (t *PetHandlerTest) TestFindOneSuccess() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -170,7 +173,7 @@ func (t *PetHandlerTest) TestFindOneSuccess() {
 	petSvc.EXPECT().FindOne(t.Pet.Id).Return(findOneResponse, nil)
 	context.EXPECT().JSON(http.StatusOK, expectedResponse)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.FindOne(context)
 }
 
@@ -181,6 +184,7 @@ func (t *PetHandlerTest) TestFindOneNotFoundErr() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -188,7 +192,7 @@ func (t *PetHandlerTest) TestFindOneNotFoundErr() {
 	petSvc.EXPECT().FindOne(t.Pet.Id).Return(nil, findOneResponse)
 	context.EXPECT().JSON(http.StatusNotFound, findOneResponse)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.FindOne(context)
 }
 
@@ -199,6 +203,7 @@ func (t *PetHandlerTest) TestFindOneGrpcErr() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -206,7 +211,7 @@ func (t *PetHandlerTest) TestFindOneGrpcErr() {
 	petSvc.EXPECT().FindOne(t.Pet.Id).Return(nil, findOneResponse)
 	context.EXPECT().JSON(http.StatusServiceUnavailable, findOneResponse)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.FindOne(context)
 }
 
@@ -222,6 +227,7 @@ func (t *PetHandlerTest) TestCreateSuccess() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -230,7 +236,7 @@ func (t *PetHandlerTest) TestCreateSuccess() {
 	petSvc.EXPECT().Create(t.CreatePetRequest).Return(createResponse, nil)
 	context.EXPECT().JSON(http.StatusCreated, expectedResponse)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.Create(context)
 }
 
@@ -241,6 +247,7 @@ func (t *PetHandlerTest) TestCreateGrpcErr() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -249,7 +256,7 @@ func (t *PetHandlerTest) TestCreateGrpcErr() {
 	petSvc.EXPECT().Create(t.CreatePetRequest).Return(nil, createErrorResponse)
 	context.EXPECT().JSON(http.StatusServiceUnavailable, createErrorResponse)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.Create(context)
 }
 
@@ -265,6 +272,7 @@ func (t *PetHandlerTest) TestUpdateSuccess() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -274,7 +282,7 @@ func (t *PetHandlerTest) TestUpdateSuccess() {
 	petSvc.EXPECT().Update(t.Pet.Id, t.UpdatePetRequest).Return(updateResponse, nil)
 	context.EXPECT().JSON(http.StatusOK, expectedResponse)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.Update(context)
 }
 
@@ -285,6 +293,7 @@ func (t *PetHandlerTest) TestUpdateNotFound() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -294,7 +303,7 @@ func (t *PetHandlerTest) TestUpdateNotFound() {
 	petSvc.EXPECT().Update(t.Pet.Id, t.UpdatePetRequest).Return(nil, updateResponse)
 	context.EXPECT().JSON(http.StatusNotFound, updateResponse)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.Update(context)
 }
 
@@ -305,6 +314,7 @@ func (t *PetHandlerTest) TestUpdateGrpcErr() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -314,7 +324,7 @@ func (t *PetHandlerTest) TestUpdateGrpcErr() {
 	petSvc.EXPECT().Update(t.Pet.Id, t.UpdatePetRequest).Return(nil, updateResponse)
 	context.EXPECT().JSON(http.StatusServiceUnavailable, updateResponse)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.Update(context)
 }
 
@@ -332,6 +342,7 @@ func (t *PetHandlerTest) TestDeleteSuccess() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -339,7 +350,7 @@ func (t *PetHandlerTest) TestDeleteSuccess() {
 	petSvc.EXPECT().Delete(t.Pet.Id).Return(deleteResponse, nil)
 	context.EXPECT().JSON(http.StatusOK, expectedResponse)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.Delete(context)
 }
 func (t *PetHandlerTest) TestDeleteNotFound() {
@@ -351,6 +362,7 @@ func (t *PetHandlerTest) TestDeleteNotFound() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -358,7 +370,7 @@ func (t *PetHandlerTest) TestDeleteNotFound() {
 	petSvc.EXPECT().Delete(t.Pet.Id).Return(deleteResponse, t.NotFoundErr)
 	context.EXPECT().JSON(http.StatusNotFound, t.NotFoundErr)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.Delete(context)
 }
 
@@ -371,6 +383,7 @@ func (t *PetHandlerTest) TestDeleteGrpcErr() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -378,7 +391,7 @@ func (t *PetHandlerTest) TestDeleteGrpcErr() {
 	petSvc.EXPECT().Delete(t.Pet.Id).Return(deleteResponse, t.ServiceDownErr)
 	context.EXPECT().JSON(http.StatusServiceUnavailable, t.ServiceDownErr)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.Delete(context)
 }
 
@@ -396,6 +409,7 @@ func (t *PetHandlerTest) TestChangeViewSuccess() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -405,7 +419,7 @@ func (t *PetHandlerTest) TestChangeViewSuccess() {
 	petSvc.EXPECT().ChangeView(t.Pet.Id, t.ChangeViewPetRequest).Return(changeViewResponse, nil)
 	context.EXPECT().JSON(http.StatusOK, expectedResponse)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.ChangeView(context)
 }
 
@@ -418,6 +432,7 @@ func (t *PetHandlerTest) TestChangeViewNotFound() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -427,7 +442,7 @@ func (t *PetHandlerTest) TestChangeViewNotFound() {
 	petSvc.EXPECT().ChangeView(t.Pet.Id, t.ChangeViewPetRequest).Return(changeViewResponse, t.NotFoundErr)
 	context.EXPECT().JSON(http.StatusNotFound, t.NotFoundErr)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.ChangeView(context)
 }
 
@@ -440,6 +455,7 @@ func (t *PetHandlerTest) TestChangeViewGrpcErr() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -449,7 +465,7 @@ func (t *PetHandlerTest) TestChangeViewGrpcErr() {
 	petSvc.EXPECT().ChangeView(t.Pet.Id, t.ChangeViewPetRequest).Return(changeViewResponse, t.ServiceDownErr)
 	context.EXPECT().JSON(http.StatusServiceUnavailable, t.ServiceDownErr)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.ChangeView(context)
 }
 
@@ -467,6 +483,7 @@ func (t *PetHandlerTest) TestAdoptSuccess() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -476,7 +493,7 @@ func (t *PetHandlerTest) TestAdoptSuccess() {
 	petSvc.EXPECT().Adopt(t.Pet.Id, t.AdoptByRequest).Return(adoptByResponse, nil)
 	context.EXPECT().JSON(http.StatusOK, expectedResponse)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.Adopt(context)
 }
 
@@ -489,6 +506,7 @@ func (t *PetHandlerTest) TestAdoptNotFound() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -498,7 +516,7 @@ func (t *PetHandlerTest) TestAdoptNotFound() {
 	petSvc.EXPECT().Adopt(t.Pet.Id, t.AdoptByRequest).Return(adoptByResponse, t.NotFoundErr)
 	context.EXPECT().JSON(http.StatusNotFound, t.NotFoundErr)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.Adopt(context)
 }
 
@@ -511,6 +529,7 @@ func (t *PetHandlerTest) TestAdoptGrpcErr() {
 
 	petSvc := petMock.NewMockService(controller)
 	imageSvc := imageMock.NewMockService(controller)
+	likeSvc := likeMock.NewMockService(controller)
 	validator := validatorMock.NewMockIDtoValidator(controller)
 	context := routerMock.NewMockIContext(controller)
 
@@ -520,6 +539,6 @@ func (t *PetHandlerTest) TestAdoptGrpcErr() {
 	petSvc.EXPECT().Adopt(t.Pet.Id, t.AdoptByRequest).Return(adoptByResponse, t.ServiceDownErr)
 	context.EXPECT().JSON(http.StatusServiceUnavailable, t.ServiceDownErr)
 
-	handler := NewHandler(petSvc, imageSvc, validator)
+	handler := NewHandler(petSvc, imageSvc, likeSvc, validator)
 	handler.Adopt(context)
 }

--- a/src/app/utils/pet/pet.utils.go
+++ b/src/app/utils/pet/pet.utils.go
@@ -160,3 +160,23 @@ func extractImages(images []*imgproto.Image) []dto.ImageResponse {
 	}
 	return result
 }
+
+func IsLike(petId string, likes []*dto.LikeResponse) *bool {
+	for _, like := range likes {
+		if like.PetID == petId {
+			return boolAddr(true)
+		}
+	}
+	return boolAddr(false)
+}
+
+func MapIsLikeToPets(likes []*dto.LikeResponse, pets []*dto.PetResponse) []*dto.PetResponse {
+	for _, pet := range pets {
+		pet.IsLike = IsLike(pet.Id, likes)
+	}
+	return pets
+}
+
+func boolAddr(b bool) *bool {
+	return &b
+}

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -234,7 +234,353 @@ const docTemplate = `{
                 }
             }
         },
-        "/v1/pet/": {
+        "/v1/likes/": {
+            "get": {
+                "description": "Return dto.ResponseSuccess",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "like"
+                ],
+                "summary": "find likes by user id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "user id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "404": {
+                        "description": "user not found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseNotfoundErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Return dto.ResponseSuccess",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "like"
+                ],
+                "summary": "create like",
+                "parameters": [
+                    {
+                        "description": "create like request",
+                        "name": "create",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateLikeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseBadRequestErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Return dto.ResponseSuccess if like is successfully deleted",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "like"
+                ],
+                "summary": "delete like",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "user id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "404": {
+                        "description": "like not found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseNotfoundErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/pets/": {
+            "get": {
+                "description": "Return the data of pets if successfully",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pet"
+                ],
+                "summary": "find all pets",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Return the status true of pet if successfully else false",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pet"
+                ],
+                "summary": "change view pet",
+                "parameters": [
+                    {
+                        "description": "change view pet dto",
+                        "name": "changeView",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ChangeViewPetRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "pet id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseBadRequestErr"
+                        }
+                    },
+                    "404": {
+                        "description": "Pet not found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseNotfoundErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Return the status true of pet if successfully else false",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pet"
+                ],
+                "summary": "delete pet",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "pet id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseBadRequestErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/pets/create": {
+            "post": {
+                "description": "Return the data of pet if successfully",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pet"
+                ],
+                "summary": "create pet",
+                "parameters": [
+                    {
+                        "description": "pet dto",
+                        "name": "create",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreatePetRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseBadRequestErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/pets/{id}": {
             "get": {
                 "description": "Return the data of pets if successfully",
                 "consumes": [
@@ -246,23 +592,78 @@ const docTemplate = `{
                 "tags": [
                     "auth"
                 ],
-                "summary": "find all pets",
+                "summary": "find one pet",
                 "parameters": [
                     {
-                        "description": "pet dto",
-                        "name": "signup",
+                        "type": "string",
+                        "description": "pet id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "404": {
+                        "description": "Pet not found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseNotfoundErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Return the data of pet if successfully",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pet"
+                ],
+                "summary": "update pet",
+                "parameters": [
+                    {
+                        "description": "update pet dto",
+                        "name": "update",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.PetDto"
+                            "$ref": "#/definitions/dto.UpdatePetRequest"
                         }
+                    },
+                    {
+                        "type": "string",
+                        "description": "pet id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.PetDto"
+                            "$ref": "#/definitions/dto.ResponseSuccess"
                         }
                     },
                     "400": {
@@ -271,10 +672,84 @@ const docTemplate = `{
                             "$ref": "#/definitions/dto.ResponseBadRequestErr"
                         }
                     },
-                    "409": {
-                        "description": "Duplicate email",
+                    "404": {
+                        "description": "Pet not found",
                         "schema": {
-                            "$ref": "#/definitions/dto.ResponseConflictErr"
+                            "$ref": "#/definitions/dto.ResponseNotfoundErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/pets/{id}/adopt": {
+            "put": {
+                "description": "Return true if the pet is successfully adopted",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Adopt a pet",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Pet ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Pet ID",
+                        "name": "pet_id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseBadRequestErr"
+                        }
+                    },
+                    "404": {
+                        "description": "Pet not found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseNotfoundErr"
                         }
                     },
                     "500": {
@@ -306,6 +781,35 @@ const docTemplate = `{
                 "value": {}
             }
         },
+        "dto.ChangeViewPetRequest": {
+            "type": "object",
+            "required": [
+                "visible"
+            ],
+            "properties": {
+                "visible": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "dto.CreateLikeRequest": {
+            "type": "object",
+            "required": [
+                "pet_id",
+                "user_id"
+            ],
+            "properties": {
+                "pet_id": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.CreatePetRequest": {
+            "type": "object"
+        },
         "dto.Credential": {
             "type": "object",
             "properties": {
@@ -333,9 +837,6 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
-        },
-        "dto.PetDto": {
-            "type": "object"
         },
         "dto.ResponseBadRequestErr": {
             "type": "object",
@@ -398,6 +899,20 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.ResponseNotfoundErr": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "message": {
+                    "type": "string",
+                    "example": "Not found"
+                },
+                "status_code": {
+                    "type": "integer",
+                    "example": 404
+                }
+            }
+        },
         "dto.ResponseServiceDownErr": {
             "type": "object",
             "properties": {
@@ -409,6 +924,20 @@ const docTemplate = `{
                 "status_code": {
                     "type": "integer",
                     "example": 503
+                }
+            }
+        },
+        "dto.ResponseSuccess": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "message": {
+                    "type": "string",
+                    "example": "success"
+                },
+                "status_code": {
+                    "type": "integer",
+                    "example": 200
                 }
             }
         },
@@ -489,6 +1018,65 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "lastname": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.UpdatePetRequest": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "adopt_by": {
+                    "type": "string"
+                },
+                "background": {
+                    "type": "string"
+                },
+                "birthdate": {
+                    "type": "string"
+                },
+                "caption": {
+                    "type": "string"
+                },
+                "contact": {
+                    "type": "string"
+                },
+                "gender": {
+                    "type": "integer"
+                },
+                "habit": {
+                    "type": "string"
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "is_club_pet": {
+                    "type": "boolean"
+                },
+                "is_sterile": {
+                    "type": "boolean"
+                },
+                "is_vaccinated": {
+                    "type": "boolean"
+                },
+                "is_visible": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "species": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "integer"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -229,7 +229,353 @@
                 }
             }
         },
-        "/v1/pet/": {
+        "/v1/likes/": {
+            "get": {
+                "description": "Return dto.ResponseSuccess",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "like"
+                ],
+                "summary": "find likes by user id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "user id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "404": {
+                        "description": "user not found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseNotfoundErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Return dto.ResponseSuccess",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "like"
+                ],
+                "summary": "create like",
+                "parameters": [
+                    {
+                        "description": "create like request",
+                        "name": "create",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreateLikeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseBadRequestErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Return dto.ResponseSuccess if like is successfully deleted",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "like"
+                ],
+                "summary": "delete like",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "user id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "404": {
+                        "description": "like not found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseNotfoundErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/pets/": {
+            "get": {
+                "description": "Return the data of pets if successfully",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pet"
+                ],
+                "summary": "find all pets",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Return the status true of pet if successfully else false",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pet"
+                ],
+                "summary": "change view pet",
+                "parameters": [
+                    {
+                        "description": "change view pet dto",
+                        "name": "changeView",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ChangeViewPetRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "pet id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseBadRequestErr"
+                        }
+                    },
+                    "404": {
+                        "description": "Pet not found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseNotfoundErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Return the status true of pet if successfully else false",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pet"
+                ],
+                "summary": "delete pet",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "pet id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseBadRequestErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/pets/create": {
+            "post": {
+                "description": "Return the data of pet if successfully",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pet"
+                ],
+                "summary": "create pet",
+                "parameters": [
+                    {
+                        "description": "pet dto",
+                        "name": "create",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CreatePetRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseBadRequestErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/pets/{id}": {
             "get": {
                 "description": "Return the data of pets if successfully",
                 "consumes": [
@@ -241,23 +587,78 @@
                 "tags": [
                     "auth"
                 ],
-                "summary": "find all pets",
+                "summary": "find one pet",
                 "parameters": [
                     {
-                        "description": "pet dto",
-                        "name": "signup",
+                        "type": "string",
+                        "description": "pet id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "404": {
+                        "description": "Pet not found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseNotfoundErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Return the data of pet if successfully",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pet"
+                ],
+                "summary": "update pet",
+                "parameters": [
+                    {
+                        "description": "update pet dto",
+                        "name": "update",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.PetDto"
+                            "$ref": "#/definitions/dto.UpdatePetRequest"
                         }
+                    },
+                    {
+                        "type": "string",
+                        "description": "pet id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.PetDto"
+                            "$ref": "#/definitions/dto.ResponseSuccess"
                         }
                     },
                     "400": {
@@ -266,10 +667,84 @@
                             "$ref": "#/definitions/dto.ResponseBadRequestErr"
                         }
                     },
-                    "409": {
-                        "description": "Duplicate email",
+                    "404": {
+                        "description": "Pet not found",
                         "schema": {
-                            "$ref": "#/definitions/dto.ResponseConflictErr"
+                            "$ref": "#/definitions/dto.ResponseNotfoundErr"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal service error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseInternalErr"
+                        }
+                    },
+                    "503": {
+                        "description": "Service is down",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseServiceDownErr"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/pets/{id}/adopt": {
+            "put": {
+                "description": "Return true if the pet is successfully adopted",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Adopt a pet",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Pet ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Pet ID",
+                        "name": "pet_id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseSuccess"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseBadRequestErr"
+                        }
+                    },
+                    "404": {
+                        "description": "Pet not found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ResponseNotfoundErr"
                         }
                     },
                     "500": {
@@ -301,6 +776,35 @@
                 "value": {}
             }
         },
+        "dto.ChangeViewPetRequest": {
+            "type": "object",
+            "required": [
+                "visible"
+            ],
+            "properties": {
+                "visible": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "dto.CreateLikeRequest": {
+            "type": "object",
+            "required": [
+                "pet_id",
+                "user_id"
+            ],
+            "properties": {
+                "pet_id": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.CreatePetRequest": {
+            "type": "object"
+        },
         "dto.Credential": {
             "type": "object",
             "properties": {
@@ -328,9 +832,6 @@
                     "type": "string"
                 }
             }
-        },
-        "dto.PetDto": {
-            "type": "object"
         },
         "dto.ResponseBadRequestErr": {
             "type": "object",
@@ -393,6 +894,20 @@
                 }
             }
         },
+        "dto.ResponseNotfoundErr": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "message": {
+                    "type": "string",
+                    "example": "Not found"
+                },
+                "status_code": {
+                    "type": "integer",
+                    "example": 404
+                }
+            }
+        },
         "dto.ResponseServiceDownErr": {
             "type": "object",
             "properties": {
@@ -404,6 +919,20 @@
                 "status_code": {
                     "type": "integer",
                     "example": 503
+                }
+            }
+        },
+        "dto.ResponseSuccess": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "message": {
+                    "type": "string",
+                    "example": "success"
+                },
+                "status_code": {
+                    "type": "integer",
+                    "example": 200
                 }
             }
         },
@@ -484,6 +1013,65 @@
                     "type": "string"
                 },
                 "lastname": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.UpdatePetRequest": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "adopt_by": {
+                    "type": "string"
+                },
+                "background": {
+                    "type": "string"
+                },
+                "birthdate": {
+                    "type": "string"
+                },
+                "caption": {
+                    "type": "string"
+                },
+                "contact": {
+                    "type": "string"
+                },
+                "gender": {
+                    "type": "integer"
+                },
+                "habit": {
+                    "type": "string"
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "is_club_pet": {
+                    "type": "boolean"
+                },
+                "is_sterile": {
+                    "type": "boolean"
+                },
+                "is_vaccinated": {
+                    "type": "boolean"
+                },
+                "is_visible": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "species": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "integer"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -7,6 +7,25 @@ definitions:
         type: string
       value: {}
     type: object
+  dto.ChangeViewPetRequest:
+    properties:
+      visible:
+        type: boolean
+    required:
+    - visible
+    type: object
+  dto.CreateLikeRequest:
+    properties:
+      pet_id:
+        type: string
+      user_id:
+        type: string
+    required:
+    - pet_id
+    - user_id
+    type: object
+  dto.CreatePetRequest:
+    type: object
   dto.Credential:
     properties:
       access_token:
@@ -25,8 +44,6 @@ definitions:
         type: string
     required:
     - refresh_token
-    type: object
-  dto.PetDto:
     type: object
   dto.ResponseBadRequestErr:
     properties:
@@ -71,6 +88,16 @@ definitions:
         example: 500
         type: integer
     type: object
+  dto.ResponseNotfoundErr:
+    properties:
+      data: {}
+      message:
+        example: Not found
+        type: string
+      status_code:
+        example: 404
+        type: integer
+    type: object
   dto.ResponseServiceDownErr:
     properties:
       data: {}
@@ -79,6 +106,16 @@ definitions:
         type: string
       status_code:
         example: 503
+        type: integer
+    type: object
+  dto.ResponseSuccess:
+    properties:
+      data: {}
+      message:
+        example: success
+        type: string
+      status_code:
+        example: 200
         type: integer
     type: object
   dto.ResponseUnauthorizedErr:
@@ -135,6 +172,45 @@ definitions:
       id:
         type: string
       lastname:
+        type: string
+    type: object
+  dto.UpdatePetRequest:
+    properties:
+      address:
+        type: string
+      adopt_by:
+        type: string
+      background:
+        type: string
+      birthdate:
+        type: string
+      caption:
+        type: string
+      contact:
+        type: string
+      gender:
+        type: integer
+      habit:
+        type: string
+      images:
+        items:
+          type: string
+        type: array
+      is_club_pet:
+        type: boolean
+      is_sterile:
+        type: boolean
+      is_vaccinated:
+        type: boolean
+      is_visible:
+        type: boolean
+      name:
+        type: string
+      species:
+        type: string
+      status:
+        type: integer
+      type:
         type: string
     type: object
 info:
@@ -287,33 +363,148 @@ paths:
       summary: Signup user
       tags:
       - auth
-  /v1/pet/:
+  /v1/likes/:
+    delete:
+      consumes:
+      - application/json
+      description: Return dto.ResponseSuccess if like is successfully deleted
+      parameters:
+      - description: user id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.ResponseSuccess'
+        "404":
+          description: like not found
+          schema:
+            $ref: '#/definitions/dto.ResponseNotfoundErr'
+        "500":
+          description: Internal service error
+          schema:
+            $ref: '#/definitions/dto.ResponseInternalErr'
+        "503":
+          description: Service is down
+          schema:
+            $ref: '#/definitions/dto.ResponseServiceDownErr'
+      summary: delete like
+      tags:
+      - like
     get:
       consumes:
       - application/json
-      description: Return the data of pets if successfully
+      description: Return dto.ResponseSuccess
       parameters:
-      - description: pet dto
+      - description: user id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.ResponseSuccess'
+        "404":
+          description: user not found
+          schema:
+            $ref: '#/definitions/dto.ResponseNotfoundErr'
+        "500":
+          description: Internal service error
+          schema:
+            $ref: '#/definitions/dto.ResponseInternalErr'
+        "503":
+          description: Service is down
+          schema:
+            $ref: '#/definitions/dto.ResponseServiceDownErr'
+      summary: find likes by user id
+      tags:
+      - like
+    post:
+      consumes:
+      - application/json
+      description: Return dto.ResponseSuccess
+      parameters:
+      - description: create like request
         in: body
-        name: signup
+        name: create
         required: true
         schema:
-          $ref: '#/definitions/dto.PetDto'
+          $ref: '#/definitions/dto.CreateLikeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.ResponseSuccess'
+        "400":
+          description: Invalid request body
+          schema:
+            $ref: '#/definitions/dto.ResponseBadRequestErr'
+        "500":
+          description: Internal service error
+          schema:
+            $ref: '#/definitions/dto.ResponseInternalErr'
+        "503":
+          description: Service is down
+          schema:
+            $ref: '#/definitions/dto.ResponseServiceDownErr'
+      summary: create like
+      tags:
+      - like
+  /v1/pets/:
+    delete:
+      consumes:
+      - application/json
+      description: Return the status true of pet if successfully else false
+      parameters:
+      - description: pet id
+        in: path
+        name: id
+        required: true
+        type: string
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.PetDto'
+            $ref: '#/definitions/dto.ResponseSuccess'
         "400":
           description: Invalid request body
           schema:
             $ref: '#/definitions/dto.ResponseBadRequestErr'
-        "409":
-          description: Duplicate email
+        "500":
+          description: Internal service error
           schema:
-            $ref: '#/definitions/dto.ResponseConflictErr'
+            $ref: '#/definitions/dto.ResponseInternalErr'
+        "503":
+          description: Service is down
+          schema:
+            $ref: '#/definitions/dto.ResponseServiceDownErr'
+      summary: delete pet
+      tags:
+      - pet
+    get:
+      consumes:
+      - application/json
+      description: Return the data of pets if successfully
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.ResponseSuccess'
         "500":
           description: Internal service error
           schema:
@@ -324,7 +515,207 @@ paths:
             $ref: '#/definitions/dto.ResponseServiceDownErr'
       summary: find all pets
       tags:
+      - pet
+    put:
+      consumes:
+      - application/json
+      description: Return the status true of pet if successfully else false
+      parameters:
+      - description: change view pet dto
+        in: body
+        name: changeView
+        required: true
+        schema:
+          $ref: '#/definitions/dto.ChangeViewPetRequest'
+      - description: pet id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.ResponseSuccess'
+        "400":
+          description: Invalid request body
+          schema:
+            $ref: '#/definitions/dto.ResponseBadRequestErr'
+        "404":
+          description: Pet not found
+          schema:
+            $ref: '#/definitions/dto.ResponseNotfoundErr'
+        "500":
+          description: Internal service error
+          schema:
+            $ref: '#/definitions/dto.ResponseInternalErr'
+        "503":
+          description: Service is down
+          schema:
+            $ref: '#/definitions/dto.ResponseServiceDownErr'
+      summary: change view pet
+      tags:
+      - pet
+  /v1/pets/{id}:
+    get:
+      consumes:
+      - application/json
+      description: Return the data of pets if successfully
+      parameters:
+      - description: pet id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.ResponseSuccess'
+        "404":
+          description: Pet not found
+          schema:
+            $ref: '#/definitions/dto.ResponseNotfoundErr'
+        "500":
+          description: Internal service error
+          schema:
+            $ref: '#/definitions/dto.ResponseInternalErr'
+        "503":
+          description: Service is down
+          schema:
+            $ref: '#/definitions/dto.ResponseServiceDownErr'
+      summary: find one pet
+      tags:
       - auth
+    put:
+      consumes:
+      - application/json
+      description: Return the data of pet if successfully
+      parameters:
+      - description: update pet dto
+        in: body
+        name: update
+        required: true
+        schema:
+          $ref: '#/definitions/dto.UpdatePetRequest'
+      - description: pet id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.ResponseSuccess'
+        "400":
+          description: Invalid request body
+          schema:
+            $ref: '#/definitions/dto.ResponseBadRequestErr'
+        "404":
+          description: Pet not found
+          schema:
+            $ref: '#/definitions/dto.ResponseNotfoundErr'
+        "500":
+          description: Internal service error
+          schema:
+            $ref: '#/definitions/dto.ResponseInternalErr'
+        "503":
+          description: Service is down
+          schema:
+            $ref: '#/definitions/dto.ResponseServiceDownErr'
+      summary: update pet
+      tags:
+      - pet
+  /v1/pets/{id}/adopt:
+    put:
+      consumes:
+      - application/json
+      description: Return true if the pet is successfully adopted
+      parameters:
+      - description: Pet ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: User ID
+        in: body
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Pet ID
+        in: body
+        name: pet_id
+        required: true
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.ResponseSuccess'
+        "400":
+          description: Invalid request body
+          schema:
+            $ref: '#/definitions/dto.ResponseBadRequestErr'
+        "404":
+          description: Pet not found
+          schema:
+            $ref: '#/definitions/dto.ResponseNotfoundErr'
+        "500":
+          description: Internal service error
+          schema:
+            $ref: '#/definitions/dto.ResponseInternalErr'
+        "503":
+          description: Service is down
+          schema:
+            $ref: '#/definitions/dto.ResponseServiceDownErr'
+      summary: Adopt a pet
+      tags:
+      - pet
+  /v1/pets/create:
+    post:
+      consumes:
+      - application/json
+      description: Return the data of pet if successfully
+      parameters:
+      - description: pet dto
+        in: body
+        name: create
+        required: true
+        schema:
+          $ref: '#/definitions/dto.CreatePetRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.ResponseSuccess'
+        "400":
+          description: Invalid request body
+          schema:
+            $ref: '#/definitions/dto.ResponseBadRequestErr'
+        "500":
+          description: Internal service error
+          schema:
+            $ref: '#/definitions/dto.ResponseInternalErr'
+        "503":
+          description: Service is down
+          schema:
+            $ref: '#/definitions/dto.ResponseServiceDownErr'
+      summary: create pet
+      tags:
+      - pet
 schemes:
 - https
 - http

--- a/src/main.go
+++ b/src/main.go
@@ -108,13 +108,13 @@ func main() {
 	imageClient := imageProto.NewImageServiceClient(fileConn)
 	imageService := imageSvc.NewService(imageClient)
 
-	petClient := petProto.NewPetServiceClient(backendConn)
-	petService := petSvc.NewService(petClient)
-	petHandler := petHdr.NewHandler(petService, imageService, v)
-
 	likeClient := likeProto.NewLikeServiceClient(backendConn)
 	likeService := likeSvc.NewService(likeClient)
 	likeHandler := likeHdr.NewHandler(likeService, v)
+
+	petClient := petProto.NewPetServiceClient(backendConn)
+	petService := petSvc.NewService(petClient)
+	petHandler := petHdr.NewHandler(petService, imageService, likeService, v)
 
 	r := router.NewFiberRouter(&authGuard, conf.App)
 


### PR DESCRIPTION
## Change made

- [x]  Bug fixes
- [x]  New features
- [ ]  Breaking changes
## Describe what you have done
- modify `FindAll` and `FindOne` to return `isLike` property when there're `bearer token`
- Docs for `likes` end point
### New Features
- `FindAll` and `FindOne` pet return `isLike` if there're `bearer token` 
### Fix
- Pet Service Test
- Pet Handler Test

### Others
- ⚠️ pet handler test still fixing

- create like 
<img width="361" alt="Screenshot 2024-01-08 at 18 58 09" src="https://github.com/isd-sgcu/johnjud-gateway/assets/84141000/668c4f5a-26ad-4f26-bb2a-4aaab96d7e45">

- find like by user id
<img width="429" alt="Screenshot 2024-01-08 at 18 58 49" src="https://github.com/isd-sgcu/johnjud-gateway/assets/84141000/6341ddb5-3b78-4af8-bc91-4c76fd2824e7">

- find all pet result with like 
<img width="378" alt="Screenshot 2024-01-08 at 18 57 56" src="https://github.com/isd-sgcu/johnjud-gateway/assets/84141000/ee1e8c78-61ab-4ddf-938a-7ef79e97dbf4">

