### PR TITLE
Gear/joh 49 johnjud gateway combine image service in to pet service

### DIFF
--- a/src/app/dto/pet.dto.go
+++ b/src/app/dto/pet.dto.go
@@ -5,24 +5,24 @@ import (
 )
 
 type PetResponse struct {
-	Id           string          `json:"id"`
-	Type         string          `json:"type"`
-	Name         string          `json:"name"`
-	Birthdate    string          `json:"birthdate"`
-	Gender       pet.Gender      `json:"gender"`
-	Color        string          `json:"color"`
-	Pattern      string          `json:"pattern"`
-	Habit        string          `json:"habit"`
-	Caption      string          `json:"caption"`
-	Status       pet.Status      `json:"status"`
-	IsSterile    *bool           `json:"is_sterile"`
-	IsVaccinated *bool           `json:"is_vaccinated"`
-	IsVisible    *bool           `json:"is_visible"`
-	Origin       string          `json:"origin"`
-	Address      string          `json:"address"`
-	Contact      string          `json:"contact"`
-	AdoptBy      string          `json:"adopt_by"`
-	Images       []ImageResponse `json:"images"`
+	Id           string           `json:"id"`
+	Type         string           `json:"type"`
+	Name         string           `json:"name"`
+	Birthdate    string           `json:"birthdate"`
+	Gender       pet.Gender       `json:"gender"`
+	Color        string           `json:"color"`
+	Pattern      string           `json:"pattern"`
+	Habit        string           `json:"habit"`
+	Caption      string           `json:"caption"`
+	Status       pet.Status       `json:"status"`
+	IsSterile    *bool            `json:"is_sterile"`
+	IsVaccinated *bool            `json:"is_vaccinated"`
+	IsVisible    *bool            `json:"is_visible"`
+	Origin       string           `json:"origin"`
+	Address      string           `json:"address"`
+	Contact      string           `json:"contact"`
+	AdoptBy      string           `json:"adopt_by"`
+	Images       []*ImageResponse `json:"images"`
 }
 
 type FindAllPetRequest struct {

--- a/src/app/handler/pet/pet.handler_test.go
+++ b/src/app/handler/pet/pet.handler_test.go
@@ -180,7 +180,7 @@ func (t *PetHandlerTest) TestFindAllSuccess() {
 }
 
 func (t *PetHandlerTest) TestFindOneSuccess() {
-	findOneResponse := utils.ProtoToDto(t.Pet, t.Images)
+	findOneResponse := utils.ProtoToDto(t.Pet, utils.ImageProtoToDto(t.Images))
 	expectedResponse := findOneResponse
 
 	controller := gomock.NewController(t.T())
@@ -235,7 +235,7 @@ func (t *PetHandlerTest) TestFindOneGrpcErr() {
 }
 
 func (t *PetHandlerTest) TestCreateSuccess() {
-	createResponse := utils.ProtoToDto(t.Pet, t.Images)
+	createResponse := utils.ProtoToDto(t.Pet, utils.ImageProtoToDto(t.Images))
 	expectedResponse := createResponse
 
 	controller := gomock.NewController(t.T())
@@ -274,7 +274,7 @@ func (t *PetHandlerTest) TestCreateGrpcErr() {
 }
 
 func (t *PetHandlerTest) TestUpdateSuccess() {
-	updateResponse := utils.ProtoToDto(t.Pet, t.Images)
+	updateResponse := utils.ProtoToDto(t.Pet, utils.ImageProtoToDto(t.Images))
 	expectedResponse := updateResponse
 
 	controller := gomock.NewController(t.T())

--- a/src/app/service/pet/pet.service.go
+++ b/src/app/service/pet/pet.service.go
@@ -156,6 +156,7 @@ func (s *Service) Create(in *dto.CreatePetRequest) (result *dto.PetResponse, err
 	if imgErrRes != nil {
 		return nil, imgErrRes
 	}
+
 	createPetResponse := utils.ProtoToDto(res.Pet, imgRes)
 	return createPetResponse, nil
 }

--- a/src/app/service/pet/pet.service.go
+++ b/src/app/service/pet/pet.service.go
@@ -144,19 +144,12 @@ func (s *Service) Create(in *dto.CreatePetRequest) (result *dto.PetResponse, err
 		}
 	}
 
-	assignRes, assignErr := s.imageService.AssignPet(&dto.AssignPetRequest{
+	_, assignErr := s.imageService.AssignPet(&dto.AssignPetRequest{
 		Ids:   in.Images,
 		PetId: res.Pet.Id,
 	})
 	if assignErr != nil {
 		return nil, assignErr
-	}
-	if assignRes.Success == false {
-		return nil, &dto.ResponseErr{
-			StatusCode: http.StatusInternalServerError,
-			Message:    constant.InternalErrorMessage,
-			Data:       nil,
-		}
 	}
 
 	imgRes, imgErrRes := s.imageService.FindByPetId(res.Pet.Id)

--- a/src/app/utils/pet/pet.utils.go
+++ b/src/app/utils/pet/pet.utils.go
@@ -29,7 +29,35 @@ func MockImageList(n int) [][]*imgproto.Image {
 	return imagesList
 }
 
-func ProtoToDto(in *petproto.Pet, images []*imgproto.Image) *dto.PetResponse {
+func ImageProtoToDto(images []*imgproto.Image) []*dto.ImageResponse {
+	var imageDto []*dto.ImageResponse
+	for _, image := range images {
+		imageDto = append(imageDto, &dto.ImageResponse{
+			Id:        image.Id,
+			Url:       image.ImageUrl,
+			ObjectKey: image.ObjectKey,
+		})
+	}
+	return imageDto
+}
+
+func ImageListProtoToDto(imagesList [][]*imgproto.Image) [][]*dto.ImageResponse {
+	var imageListDto [][]*dto.ImageResponse
+	for _, images := range imagesList {
+		var imageDto []*dto.ImageResponse
+		for _, image := range images {
+			imageDto = append(imageDto, &dto.ImageResponse{
+				Id:        image.Id,
+				Url:       image.ImageUrl,
+				ObjectKey: image.ObjectKey,
+			})
+		}
+		imageListDto = append(imageListDto, imageDto)
+	}
+	return imageListDto
+}
+
+func ProtoToDto(in *petproto.Pet, images []*dto.ImageResponse) *dto.PetResponse {
 	pet := &dto.PetResponse{
 		Id:           in.Id,
 		Type:         in.Type,
@@ -48,7 +76,7 @@ func ProtoToDto(in *petproto.Pet, images []*imgproto.Image) *dto.PetResponse {
 		Address:      in.Address,
 		Contact:      in.Contact,
 		AdoptBy:      in.AdoptBy,
-		Images:       extractImages(images),
+		Images:       images,
 	}
 	return pet
 }
@@ -122,7 +150,7 @@ func ProtoToDtoList(in []*petproto.Pet, imagesList [][]*imgproto.Image) []*dto.P
 			Address:      p.Address,
 			Contact:      p.Contact,
 			AdoptBy:      p.AdoptBy,
-			Images:       extractImages(imagesList[i]),
+			Images:       ImageProtoToDto(imagesList[i]),
 		}
 		resp = append(resp, pet)
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -120,7 +120,7 @@ func main() {
 	imageHandler := imageHdr.NewHandler(imageService, v, conf.App.MaxFileSize)
 
 	petClient := petProto.NewPetServiceClient(backendConn)
-	petService := petSvc.NewService(petClient)
+	petService := petSvc.NewService(petClient, imageService)
 	petHandler := petHdr.NewHandler(petService, imageService, v)
 
 	likeClient := likeProto.NewLikeServiceClient(backendConn)

--- a/src/mocks/client/image/image.mock.go
+++ b/src/mocks/client/image/image.mock.go
@@ -1,0 +1,49 @@
+package image
+
+import (
+	"context"
+
+	imageProto "github.com/isd-sgcu/johnjud-go-proto/johnjud/file/image/v1"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc"
+)
+
+type ImageClientMock struct {
+	mock.Mock
+}
+
+func (c *ImageClientMock) Upload(_ context.Context, in *imageProto.UploadImageRequest, _ ...grpc.CallOption) (res *imageProto.UploadImageResponse, err error) {
+	args := c.Called(in)
+
+	if args.Get(0) != nil {
+		res = args.Get(0).(*imageProto.UploadImageResponse)
+	}
+	return res, args.Error(1)
+}
+
+func (c *ImageClientMock) FindByPetId(_ context.Context, in *imageProto.FindImageByPetIdRequest, _ ...grpc.CallOption) (res *imageProto.FindImageByPetIdResponse, err error) {
+	args := c.Called(in)
+
+	if args.Get(0) != nil {
+		res = args.Get(0).(*imageProto.FindImageByPetIdResponse)
+	}
+	return res, args.Error(1)
+}
+
+func (c *ImageClientMock) AssignPet(_ context.Context, in *imageProto.AssignPetRequest, _ ...grpc.CallOption) (res *imageProto.AssignPetResponse, err error) {
+	args := c.Called(in)
+
+	if args.Get(0) != nil {
+		res = args.Get(0).(*imageProto.AssignPetResponse)
+	}
+	return res, args.Error(1)
+}
+
+func (c *ImageClientMock) Delete(_ context.Context, in *imageProto.DeleteImageRequest, _ ...grpc.CallOption) (res *imageProto.DeleteImageResponse, err error) {
+	args := c.Called(in)
+
+	if args.Get(0) != nil {
+		res = args.Get(0).(*imageProto.DeleteImageResponse)
+	}
+	return res, args.Error(1)
+}


### PR DESCRIPTION
## Change made

- [ ]  Bug fixes
- []  New features
- [x]  Breaking changes
## Describe what you have done
- use `image service` instead of `mock` image in`FindOne` and `Create` service

**FindOne**
use `imageService.FindByPetId`
**Create**
i assign pet to img by using `imageService.AssignPet` and then use `imageService.FindByPetId` for return image urls of created images
### New Features

### Fix
- Pet `Handler` and `Service` test
- Pet `Utils`: I utilize 'ImageProtoToDto' and 'ImageListP...' instead of 'extractImage' to maintain consistency in naming conventions.

### Others
